### PR TITLE
Split CI builds tp accomodate different scenarios

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,4 +1,4 @@
-name: POC Controls CI
+name: PR POC Controls CI
 
 on:
   pull_request:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,0 +1,95 @@
+name: POC Controls CI
+
+on:
+  pull_request:
+    branches: [ main ]
+    paths: controls/**
+
+jobs:
+  unit-test:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up JDK 11
+      uses: actions/setup-java@v1
+      with:
+        java-version: 11
+    - name: Cache Maven packages
+      uses: actions/cache@v2
+      with:
+        path: ~/.m2
+        key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+        restore-keys: ${{ runner.os }}-m2  
+    - name: Build with Maven
+      run: mvn -B test --file controls/pom.xml
+
+  integration-native-test:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up JDK 11
+      uses: actions/setup-java@v1
+      with:
+        java-version: 11
+    - name: Cache Maven packages
+      uses: actions/cache@v2
+      with:
+        path: ~/.m2
+        key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+        restore-keys: ${{ runner.os }}-m2  
+    - name: Build with Maven
+      run: mvn -B verify -Pnative -Dquarkus-profile=test --file controls/pom.xml
+
+  build-jvm-container:
+    name: Build and push JVM image
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up JDK 11
+      uses: actions/setup-java@v1
+      with:
+        java-version: 11
+    - name: Cache Maven packages
+      uses: actions/cache@v2
+      with:
+        path: ~/.m2
+        key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+        restore-keys: ${{ runner.os }}-m2
+    - name: Inject slug/short variables
+      uses: rlespinasse/github-slug-action@v3.x
+    - name: Build Image for PR with Maven
+      if: ${{ github.event_name == 'pull_request' }}
+      run: mvn -B package --file controls/pom.xml -Pcontainer-image -DskipTests -Dquarkus.container-image.push=true -Dquarkus.container-image.group=${{ github.repository_owner }} -Dquarkus.container-image.tag=${{ env.GITHUB_SHA_SHORT }}-jar -Dquarkus.container-image.additional-tags=${{ env.GITHUB_HEAD_REF_SLUG }}-jar -Dquarkus.container-image.registry=${{ secrets.QUAY_REPO }} -Dquarkus.container-image.username=${{ secrets.QUAY_ROBOT_USERNAME }} -Dquarkus.container-image.password=${{ secrets.QUAY_ROBOT_TOKEN }} -Dquarkus.jib.labels.\"quay.expires-after\"=3d
+    - name: Build Image for main branch with Maven
+      if: ${{ github.event_name == 'push' }}
+      run: mvn -B package --file controls/pom.xml -Pcontainer-image -DskipTests -Dquarkus.container-image.push=true -Dquarkus.container-image.group=${{ github.repository_owner }} -Dquarkus.container-image.additional-tags=latest-jar -Dquarkus.container-image.registry=${{ secrets.QUAY_REPO }} -Dquarkus.container-image.username=${{ secrets.QUAY_ROBOT_USERNAME }} -Dquarkus.container-image.password=${{ secrets.QUAY_ROBOT_TOKEN }}
+
+  build-native-container:
+    name: Build and push native image
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up JDK 11
+      uses: actions/setup-java@v1
+      with:
+        java-version: 11
+    - name: Cache Maven packages
+      uses: actions/cache@v2
+      with:
+        path: ~/.m2
+        key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+        restore-keys: ${{ runner.os }}-m2
+    - name: Inject slug/short variables
+      uses: rlespinasse/github-slug-action@v3.x
+    - name: Build Image for PR with Maven
+      if: ${{ github.event_name == 'pull_request' }}
+      run: mvn -B package --file controls/pom.xml -Pcontainer-image -Pnative -DskipTests -Dquarkus.container-image.push=true -Dquarkus.container-image.group=${{ github.repository_owner }} -Dquarkus.container-image.tag=${{ env.GITHUB_SHA_SHORT }}-native -Dquarkus.container-image.additional-tags=${{ env.GITHUB_HEAD_REF_SLUG }}-native -Dquarkus.container-image.registry=${{ secrets.QUAY_REPO }} -Dquarkus.container-image.username=${{ secrets.QUAY_ROBOT_USERNAME }} -Dquarkus.container-image.password=${{ secrets.QUAY_ROBOT_TOKEN }} -Dquarkus.jib.labels.\"quay.expires-after\"=3d
+    - name: Build Image for main branch with Maven
+      if: ${{ github.event_name == 'push' }}
+      run: mvn -B package --file controls/pom.xml -Pcontainer-image -Pnative -DskipTests -Dquarkus.container-image.push=true -Dquarkus.container-image.group=${{ github.repository_owner }} -Dquarkus.container-image.additional-tags=latest-native -Dquarkus.container-image.registry=${{ secrets.QUAY_REPO }} -Dquarkus.container-image.username=${{ secrets.QUAY_ROBOT_USERNAME }} -Dquarkus.container-image.password=${{ secrets.QUAY_ROBOT_TOKEN }}

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -4,9 +4,6 @@ on:
   push:
     branches: [ main ]
     paths: controls/**
-  pull_request:
-    branches: [ main ]
-    paths: controls/**
 
 jobs:
   unit-test:
@@ -50,6 +47,7 @@ jobs:
   build-jvm-container:
     name: Build and push JVM image
     runs-on: ubuntu-latest
+    needs: [unit-test]
 
     steps:
     - uses: actions/checkout@v2
@@ -75,6 +73,7 @@ jobs:
   build-native-container:
     name: Build and push native image
     runs-on: ubuntu-latest
+    needs: [integration-native-test]
 
     steps:
     - uses: actions/checkout@v2

--- a/controls/README.md
+++ b/controls/README.md
@@ -353,7 +353,7 @@ where
 
 ### Openshift
 
-*TBD* 
+*TBD*
 
 ## Performance testing
 


### PR DESCRIPTION
The idea behind the split:

- if we are in a PR, the CI builds should create the container images without depending on the outcome of the tests because it can happen that WIP PRs are meant to fail tests initially but they're anyway worth begin deployed in CI for some manual test and evaluation
- on the other side, the CI builds triggered when a new commit is push to official `main` repo branch should create the images if and only if all the tests are fine to avoid creating "latest/snapshot" container images based on "broken" code
