### PR TITLE
Wait for both test sets to succeed before creating container images

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -47,7 +47,7 @@ jobs:
   build-jvm-container:
     name: Build and push JVM image
     runs-on: ubuntu-latest
-    needs: [unit-test]
+    needs: [unit-test, integration-native-test]
 
     steps:
     - uses: actions/checkout@v2
@@ -73,7 +73,7 @@ jobs:
   build-native-container:
     name: Build and push native image
     runs-on: ubuntu-latest
-    needs: [integration-native-test]
+    needs: [unit-test, integration-native-test]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Done in order to avoid having the `jar` container to be created and pushed with latest code version and, in case of IT failure, having different code versions inside `jar` and `native` images.