### PR TITLE
Added '_metadata' with total count field to the '_embedded' response object

### DIFF
--- a/controls/src/main/java/io/tackle/controls/resources/hal/HalCollectionEnrichedWrapper.java
+++ b/controls/src/main/java/io/tackle/controls/resources/hal/HalCollectionEnrichedWrapper.java
@@ -9,12 +9,18 @@ import java.util.Collection;
 @JsonSerialize(using = HalCollectionEnrichedWrapperJacksonSerializer.class)
 public class HalCollectionEnrichedWrapper extends HalCollectionWrapper {
 
+    /**
+     * TODO Decide which one to keep: metadata object or straight totalCount field?
+     * I prefer metadata object because it's inside the '_embedded' component of the
+     * HAL response and it contains the metadata about the embedded collection
+     * referenced by the name of resources type with the collection.
+     */
     private final Metadata metadata;
     private final long totalCount;
 
     public HalCollectionEnrichedWrapper(Collection<Object> collection, Class<?> elementType, String collectionName, long totalCount) {
         super(collection, elementType, collectionName);
-        metadata = Metadata.withCount(totalCount);
+        metadata = Metadata.withTotalCount(totalCount);
         this.totalCount = totalCount;
     }
 

--- a/controls/src/main/java/io/tackle/controls/resources/hal/HalCollectionEnrichedWrapperJacksonSerializer.java
+++ b/controls/src/main/java/io/tackle/controls/resources/hal/HalCollectionEnrichedWrapperJacksonSerializer.java
@@ -46,6 +46,8 @@ public class HalCollectionEnrichedWrapperJacksonSerializer extends JsonSerialize
             entitySerializer.serialize(new HalEntityWrapper(entity), generator, serializers);
         }
         generator.writeEndArray();
+        generator.writeFieldName("_metadata");
+        generator.writeObject(wrapper.getMetadata());
         generator.writeEndObject();
     }
 

--- a/controls/src/main/java/io/tackle/controls/resources/responses/Metadata.java
+++ b/controls/src/main/java/io/tackle/controls/resources/responses/Metadata.java
@@ -4,13 +4,13 @@ import io.quarkus.runtime.annotations.RegisterForReflection;
 
 @RegisterForReflection
 public class Metadata {
-    public long count;
+    public long totalCount;
 
     private Metadata() {}
 
-    public static Metadata withCount(long count) {
+    public static Metadata withTotalCount(long totalCount) {
         Metadata metadata = new Metadata();
-        metadata.count = count;
+        metadata.totalCount = totalCount;
         return metadata;
     }
 }

--- a/controls/src/test/java/io/tackle/controls/resources/ServicesParameterizedTest.java
+++ b/controls/src/test/java/io/tackle/controls/resources/ServicesParameterizedTest.java
@@ -27,10 +27,12 @@ public class ServicesParameterizedTest extends SecuredResourceTest {
     @DisplayName("testListHalEndpoint")
     @ParameterizedTest(name = "{index} ==> Resource ''{0}'' tested is {1}")
     @CsvSource({
-            "stakeholder,      2, 4::5   , displayName, Jessica Fletcher::Emmett Brown                              , 5",
-            "business-service, 3, 1::2::3, name       , Home Banking BU::Online Investments service::Credit Cards BS, 2"
+            "stakeholder,      2, 4::5   , displayName, Jessica Fletcher::Emmett Brown                              , 5, 2",
+            "business-service, 3, 1::2::3, name       , Home Banking BU::Online Investments service::Credit Cards BS, 2, 3"
     })
-    public void testListHalEndpoint(String resource, int size, @ConvertWith(CSVtoArray.class) Integer[] ids, String anotherFieldName, @ConvertWith(CSVtoArray.class) String[] anotherFieldValues, int selfId) {
+    public void testListHalEndpoint(String resource, int size, @ConvertWith(CSVtoArray.class) Integer[] ids,
+                                    String anotherFieldName, @ConvertWith(CSVtoArray.class) String[] anotherFieldValues,
+                                    int selfId, int totalCount) {
         given()
                 .accept("application/hal+json")
                 .queryParam("sort", "id")
@@ -42,6 +44,7 @@ public class ServicesParameterizedTest extends SecuredResourceTest {
                         String.format("_embedded.%s.%s", resource, anotherFieldName), containsInRelativeOrder(anotherFieldValues),
                         String.format("_embedded.%s[1]._links.size()", resource), is(5),
                         String.format("_embedded.%s[1]._links.self.href", resource), is(String.format("http://localhost:8081/controls/%s/%d", resource, selfId)),
+                        String.format("_embedded._metadata.totalCount", resource), is(totalCount),
                         "_links.size()", is(4));
     }
 


### PR DESCRIPTION
`totalCount` response's field refers to the total count of elements contained the `_embedded` object of the HAL response so a `_metadata` object has been added inside the `_embedded` object to collect all the fields (right now just `totalCount`) referring to the collection within the `_embedded` object itself.