### PR TITLE
Fix createTime value management

### DIFF
--- a/controls/src/main/java/io/tackle/controls/entities/AbstractEntity.java
+++ b/controls/src/main/java/io/tackle/controls/entities/AbstractEntity.java
@@ -7,6 +7,7 @@ import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
 
 import javax.enterprise.inject.spi.CDI;
+import javax.persistence.Column;
 import javax.persistence.MappedSuperclass;
 import javax.persistence.PrePersist;
 import javax.persistence.PreUpdate;
@@ -18,6 +19,7 @@ public abstract class AbstractEntity extends PanacheEntity {
     //    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss.SSSSSSx")
     @JsonIgnore
     @CreationTimestamp
+    @Column(updatable=false)
     public Instant createTime;
     //    @JsonIgnore
     public String createUser;

--- a/controls/src/test/java/io/tackle/controls/resources/NativeBusinessServiceIT.java
+++ b/controls/src/test/java/io/tackle/controls/resources/NativeBusinessServiceIT.java
@@ -1,6 +1,14 @@
 package io.tackle.controls.resources;
 
 import io.quarkus.test.junit.NativeImageTest;
+import org.junit.jupiter.api.Test;
 
 @NativeImageTest
-public class NativeBusinessServiceIT extends BusinessServiceTest {}
+public class NativeBusinessServiceIT extends BusinessServiceTest {
+
+    @Test
+    public void testBusinessServiceCreateUpdateAndDeleteEndpointNative() {
+        testBusinessServiceCreateUpdateAndDeleteEndpoint(true);
+    }
+
+}


### PR DESCRIPTION
`createTime` value was blanked after the first update to an entity.
Made it not updatable anymore and added a test (just for JVM mode) to check the DB status.